### PR TITLE
update baseline to latest vcpkg

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name" : "banana-project",
   "version-string" : "1.0.0",
-  "builtin-baseline" : "7f9f0e44db287e8e67c0e888141bfa200ab45121",
+  "builtin-baseline" : "501cb01e517ee5689577bb01ba8bd1b4c1041a53",
   "dependencies" : [ {
     "name" : "gtest",
     "version>=" : "1.14.0"


### PR DESCRIPTION
this is needed due to the fallout from the [xz backdoor]: xz is a transient dependency of OpenCV and the previous baseline referenced a version which has now been yanked as it contained the backdoor. see also [vcpkg#37893].

[xz backdoor]: https://tukaani.org/xz-backdoor/
[vcpkg#37893]: https://github.com/microsoft/vcpkg/issues/37893