### PR TITLE
CI: skip testing on ubuntu until 24.04 is avialable on GHA

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -20,21 +20,21 @@ jobs:
       #
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [windows-latest] # skip ubuntu until 24.04 is available in GHA (required for newer GCC & CLang)
         build_type: [Debug]
-        c_compiler: [gcc, cl]
-        include:
-          - os: windows-latest
-            c_compiler: cl
-            cpp_compiler: cl
-          - os: ubuntu-latest
-            c_compiler: gcc
-            cpp_compiler: g++
-        exclude:
-          - os: windows-latest
-            c_compiler: gcc
-          - os: ubuntu-latest
-            c_compiler: cl
+        c_compiler: [cl] # skip gcc & clang until ubuntu 24.04 is available in GHA
+#        include:
+#          - os: windows-latest
+#            c_compiler: cl
+#            cpp_compiler: cl
+#          - os: ubuntu-latest
+#            c_compiler: gcc
+#            cpp_compiler: g++
+#        exclude:
+#          - os: windows-latest
+#            c_compiler: gcc
+#          - os: ubuntu-latest
+#            c_compiler: cl
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
the new code now requires `std::views` which is not yet supported in GCC 13.1 (available on Ubuntu 22.04, the current `ubuntu-latest` in GHA). as it's quite cumbersome to install GCC 13.2 (which adds support for this and has been released nearly a year ago) the easiest option for now to move forward is to just disable the Ubuntu tests. GHA will soon have the new Ubuntu 24.04 available for beta-testing
(see actions/runner-images#9691) at which point we can try to re-enable it based on the new beta. this should then also enable us to start testing with CLang again.

for the time being tests will only run on Windows against MSVC (which is new enough and supports all needed C++23 features).