### PR TITLE
additionally filter contours by their size

### DIFF
--- a/apps/livecam/main.cpp
+++ b/apps/livecam/main.cpp
@@ -39,7 +39,7 @@ int main(int const argc, char const * const argv[]) {
 
     banana::Analyzer const analyzer{{
         .verbose_annotations = true,
-        .pixels_per_meter = 12370, // measured 10cm = 1237 on "reference-measurement.jpg"
+        .pixels_per_meter = 2000, // measured 29cm = 580px
     }};
     try {
         auto cap = GetVideoCaptureFromArgs(argc, argv);

--- a/include/banana-lib/lib.hpp
+++ b/include/banana-lib/lib.hpp
@@ -118,6 +118,12 @@ namespace banana {
             /// Maximum score of `cv::matchShapes` which we still accept as a banana.
             float const match_max_score{0.6f};
 
+            /// Minimum area value of a banana (in px^2).
+            float const min_area{1e5f};
+
+            /// Maximum area value of a banana (in px^2).
+            float const max_area{1e7f};
+
             /// How long (in pixels) is a meter? This is the extrinsic calibration needed to calculate sizes.
             double const pixels_per_meter;
 

--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -308,7 +308,7 @@ namespace banana {
         // rotate the center line back so that it fits on the image
         auto const rotated_center_line = this->RotateContour(center_line_points2i, result.estimated_center, -result.rotation_angle);
 
-        cv::polylines(draw_target, rotated_center_line, false, this->settings_.helper_annotation_color, 10);
+        cv::polylines(draw_target, rotated_center_line, false, this->settings_.helper_annotation_color, 3);
     }
 
     void Analyzer::PlotPCAResult(cv::Mat& draw_target, AnalysisResult const& result) const {
@@ -325,7 +325,7 @@ namespace banana {
         auto annotated_image = cv::Mat{image};
 
         for (auto const& [n, result] : std::ranges::enumerate_view(analysis_result)) {
-            cv::drawContours(annotated_image, std::vector{{result.contour}}, -1, this->settings_.contour_annotation_color, 10);
+            cv::drawContours(annotated_image, std::vector{{result.contour}}, -1, this->settings_.contour_annotation_color, 3);
 
             if (this->settings_.verbose_annotations) {
                 cv::putText(annotated_image, std::to_string(n), result.estimated_center + cv::Point{35, -35}, cv::FONT_HERSHEY_COMPLEX_SMALL, 2, this->settings_.helper_annotation_color);


### PR DESCRIPTION
this allows filtering out some false-positives which were so far incorrectly recognized as bananas.