### PR TITLE
CI: build with GCC 14 on Ubuntu 24.04

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -10,15 +10,8 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
-      # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
       fail-fast: false
 
-      # Set up a matrix to run the following 3 configurations:
-      # 1. <Windows, Debug, latest MSVC compiler toolchain on the default runner image, default generator>
-      # 2. <Linux, Debug, latest GCC compiler toolchain on the default runner image, default generator>
-      # 3. <Linux, Debug, latest Clang compiler toolchain on the default runner image, default generator>
-      #
-      # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
         os: [windows-latest, ubuntu-24.04]
         build_type: [Debug]
@@ -39,12 +32,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set reusable strings
-        # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
-        id: strings
-        shell: bash
-        run: |
-          echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+      - name: Install CMake + Ninja
+        uses: lukka/get-cmake@latest
 
       # install dependencies of dependencies (based on CI failures)
       - name: install dependencies
@@ -56,23 +45,14 @@ jobs:
       - name: Setup vcpkg (incl. caching)
         uses: lukka/run-vcpkg@v11
 
-      - name: Configure CMake
-        # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-        # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-        run: >
-          cmake -B ${{ steps.strings.outputs.build-output-dir }}
-          -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
-          -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
-          -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
-          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-          -S ${{ github.workspace }}
-
-      - name: Build
-        # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
-        run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
-
-      - name: Test
-        working-directory: ${{ steps.strings.outputs.build-output-dir }}
-        # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
-        # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-        run: ctest --build-config ${{ matrix.build_type }} --output-on-failure
+      - name: Run CMake
+        uses: lukka/run-cmake@v10
+        with:
+          configurePreset: ninja-multi-vcpkg
+          buildPreset: ninja-multi-vcpkg
+          testPreset: ninja-multi-vcpkg
+          configurePresetAdditionalArgs: "[
+            '-DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}',
+            '-DCMAKE_C_COMPILER=${{ matrix.c_compiler }}',
+            '-DCMAKE_BUILD_TYPE=${{ matrix.build_type }}'
+          ]"

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -40,7 +40,7 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-24.04' }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y libxi-dev libxtst-dev libxrandr-dev libx11-dev libxft-dev libxext-dev
+          sudo apt-get install -y libxi-dev libxtst-dev libxrandr-dev libx11-dev libxft-dev libxext-dev libltdl-dev
 
       - name: Setup vcpkg (incl. caching)
         uses: lukka/run-vcpkg@v11

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -40,7 +40,7 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-24.04' }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y libxi-dev libxtst-dev libxrandr-dev
+          sudo apt-get install -y libxi-dev libxtst-dev libxrandr-dev libx11-dev libxft-dev libxext-dev
 
       - name: Setup vcpkg (incl. caching)
         uses: lukka/run-vcpkg@v11

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -56,3 +56,10 @@ jobs:
             '-DCMAKE_C_COMPILER=${{ matrix.c_compiler }}',
             '-DCMAKE_BUILD_TYPE=${{ matrix.build_type }}'
           ]"
+      - name: upload logs
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: vcpkg-buildtree-logs-${{ matrix.os }}
+          path: |
+            vcpkg/buildtrees/**/*.log

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -63,3 +63,14 @@ jobs:
           name: vcpkg-buildtree-logs-${{ matrix.os }}
           path: |
             vcpkg/buildtrees/**/*.log
+
+  # simplify GH settings: have one single build to be required
+  build-results:
+    name: Final Results
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: check for failed builds
+        if: ${{ needs.build.result != 'success' }}
+        run: exit 1

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -20,21 +20,21 @@ jobs:
       #
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
-        os: [windows-latest] # skip ubuntu until 24.04 is available in GHA (required for newer GCC & CLang)
+        os: [windows-latest, ubuntu-24.04]
         build_type: [Debug]
-        c_compiler: [cl] # skip gcc & clang until ubuntu 24.04 is available in GHA
-#        include:
-#          - os: windows-latest
-#            c_compiler: cl
-#            cpp_compiler: cl
-#          - os: ubuntu-latest
-#            c_compiler: gcc
-#            cpp_compiler: g++
-#        exclude:
-#          - os: windows-latest
-#            c_compiler: gcc
-#          - os: ubuntu-latest
-#            c_compiler: cl
+        c_compiler: [cl, gcc-14]
+        include:
+          - os: windows-latest
+            c_compiler: cl
+            cpp_compiler: cl
+          - os: ubuntu-24.04
+            c_compiler: gcc-14
+            cpp_compiler: g++-14
+        exclude:
+          - os: windows-latest
+            c_compiler: gcc-14
+          - os: ubuntu-24.04
+            c_compiler: cl
 
     steps:
       - uses: actions/checkout@v4
@@ -46,16 +46,9 @@ jobs:
         run: |
           echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
 
-      # the current image contains an older version of gcc which doesn't support all needed C++23 features yet
-      - name: Install latest gcc
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        uses: egor-tensin/setup-gcc@v1
-        with:
-          version: 13
-
       # install dependencies of dependencies (based on CI failures)
       - name: install dependencies
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-24.04' }}
         run: |
           sudo apt-get update
           sudo apt-get install -y libxi-dev libxtst-dev libxrandr-dev

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 cmake-build*/
 .ipynb_checkpoints/
+builds/

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,100 @@
+{
+  "version": 6,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 29,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "ninja-multi-vcpkg",
+      "displayName": "Ninja Multi-Config Configure Settings",
+      "description": "Configure with vcpkg toolchain",
+      "binaryDir": "${sourceDir}/builds/${presetName}",
+      "generator": "Ninja Multi-Config",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": {
+          "type": "FILEPATH",
+          "value": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+        }
+      }
+    },
+    {
+      "name": "msbuild-vcpkg",
+      "displayName": "MSBuild (vcpkg toolchain) Configure Settings",
+      "description": "Configure with VS generators and with vcpkg toolchain",
+      "binaryDir": "${sourceDir}/builds/${presetName}",
+      "generator": "Visual Studio 17 2022",
+      "architecture": {
+        "strategy": "set",
+        "value": "x64"
+      },
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": {
+          "type": "FILEPATH",
+          "value": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+        }
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "ninja-multi-vcpkg",
+      "configurePreset": "ninja-multi-vcpkg",
+      "displayName": "Build ninja-multi-vcpkg",
+      "description": "Build ninja-multi-vcpkg Configurations"
+    },
+    {
+      "name": "msbuild-vcpkg",
+      "configurePreset": "msbuild-vcpkg",
+      "displayName": "Build MSBuild",
+      "description": "Build with MSBuild (VS)"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "ninja-multi-vcpkg",
+      "configurePreset": "ninja-multi-vcpkg"
+    },
+    {
+      "name": "msbuild-vcpkg",
+      "configurePreset": "msbuild-vcpkg"
+    }
+  ],
+  "workflowPresets": [
+    {
+      "name": "ninja-workflow",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "ninja-multi-vcpkg"
+        },
+        {
+          "type": "build",
+          "name": "ninja-multi-vcpkg"
+        },
+        {
+          "type": "test",
+          "name": "ninja-multi-vcpkg"
+        }
+      ]
+    },
+    {
+      "name": "msbuild-workflow",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "msbuild-vcpkg"
+        },
+        {
+          "type": "build",
+          "name": "msbuild-vcpkg"
+        },
+        {
+          "type": "test",
+          "name": "msbuild-vcpkg"
+        }
+      ]
+    }
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name" : "banana-project",
   "version-string" : "1.0.0",
-  "builtin-baseline" : "501cb01e517ee5689577bb01ba8bd1b4c1041a53",
+  "builtin-baseline" : "eba7c6a894fce24146af4fdf161fef8e90dd6be3",
   "dependencies" : [ {
     "name" : "gtest",
     "version>=" : "1.14.0"


### PR DESCRIPTION
GHA now supports Ubuntu 24.04 as a beta (will become `ubuntu-latest` once 24.04 LTS is released in autumn). with GCC 14 the project compiles fine. it _should_ also compile with CLang 18, however i didn't get that to work as Ubuntu ships with `libstdc++` (the C++ standard library from GCC) which requires a newer version of "concepts" for `std::expected` to work than what CLang implements - it should work with `libc++` (the C++ standard library from CLang/LLVM), but that'd be much harder to set up and isn't worth it now.